### PR TITLE
🔀 :: (#1) - 가로길이 조정 방식 추가

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,0 +1,56 @@
+name: Android CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: "zulu"
+          java-version: 11
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v2
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Cache Gradle Packages
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{runner.os}}-gradle-${{hashFiles('**/*.gradle*', '**/gradle-wrapper.properties')}}
+          restore-keys: |
+            ${{runner.os}}-gradle-
+
+      - name: Build with Gradle
+        run: ./gradlew build
+
+      - name: SMS Android CI Discord Notification
+        uses: sarisia/actions-status-discord@v1
+        if: ${{ success() }}
+        with:
+          title: ✅ SMS-Android-CI 성공! ✅
+          webhook: ${{ secrets.SMS_DISCORD_WEBHOOK }}
+          color: 00FF00
+
+      - name: SMS Android CI Discord Notification
+        uses: sarisia/actions-status-discord@v1
+        if: ${{ failure() }}
+        with:
+          title: ❗️ SMS-Android-CI 실패! ❗️
+          webhook: ${{ secrets.SMS_DISCORD_WEBHOOK }}
+          color: FF0000

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -43,14 +43,14 @@ jobs:
         uses: sarisia/actions-status-discord@v1
         if: ${{ success() }}
         with:
-          title: ✅ SMS-Android-CI 성공! ✅
-          webhook: ${{ secrets.SMS_DISCORD_WEBHOOK }}
+          title: ✅ GAuth-Android-CI 성공! ✅
+          webhook: ${{ secrets.GAUTH_DISCORD_WEBHOOK }}
           color: 00FF00
 
       - name: SMS Android CI Discord Notification
         uses: sarisia/actions-status-discord@v1
         if: ${{ failure() }}
         with:
-          title: ❗️ SMS-Android-CI 실패! ❗️
-          webhook: ${{ secrets.SMS_DISCORD_WEBHOOK }}
+          title: ❗️ GAuth-Android-CI 실패! ❗️
+          webhook: ${{ secrets.GAUTH_DISCORD_WEBHOOK }}
           color: FF0000

--- a/GAuthSignin/src/main/java/com/msg/gauthsignin/component/GAuthButton.kt
+++ b/GAuthSignin/src/main/java/com/msg/gauthsignin/component/GAuthButton.kt
@@ -31,74 +31,87 @@ fun GAuthButton(
     style: Types.Style,
     actionType: Types.ActionType,
     colors: Types.Colors,
-    horizontalPaddingValue: Dp,
+    horizontalPaddingValue: Dp? = null,
+    horizontalFloat: Float? = null,
+    horizontalMargin: Dp? = null,
     onClick: () -> Unit
 ) {
     val pretendard = FontFamily(
         Font(R.font.pretendardsemibold, FontWeight.SemiBold, FontStyle.Normal)
     )
-
-    Button(
-        onClick = onClick,
+    Box(
         modifier = Modifier
-            .wrapContentSize()
-            .clip(
-                RoundedCornerShape(
-                    when (style) {
-                        Types.Style.DEFAULT -> 6.dp
-                        Types.Style.ROUNDED -> 26.dp
-                    }
-                )
-            )
-            .border(
-                if (colors == Types.Colors.OUTLINE) 1.dp else 0.dp,
-                SolidColor(
-                    when (colors) {
-                        Types.Colors.OUTLINE -> GauthBlue
-                        Types.Colors.COLORED -> GauthBlue
-                        Types.Colors.WHITE -> Color.White
-                    }
-                ),
-                RoundedCornerShape(if (style == Types.Style.DEFAULT) 6.dp else 26.dp)
-            ),
-        contentPadding = PaddingValues(vertical = 14.dp, horizontal = horizontalPaddingValue),
-        colors = ButtonDefaults.buttonColors(
-            backgroundColor = when (colors) {
-                Types.Colors.COLORED -> GauthBlue
-                else -> Color.White
-            },
-            contentColor = when (colors) {
-                Types.Colors.WHITE -> GauthBlue
-                Types.Colors.COLORED -> Color.White
-                Types.Colors.OUTLINE -> GauthBlue
-            }
-        ),
+            .fillMaxWidth()
+            .wrapContentHeight()
+            .padding(vertical = horizontalMargin ?: 0.dp),
     ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.Center
-        ) {
-            Icon(
-                painter = painterResource(id = R.drawable.gauth_white_ic),
-                contentDescription = "GAuthButtonIcon",
-                modifier = Modifier
-                    .width(30.dp)
-                    .height(30.dp)
-            )
-            Text(
-                text = "${
-                    when (actionType) {
-                        Types.ActionType.SIGNIN -> "Sign in"
-                        Types.ActionType.SIGNUP -> "Sign up"
-                        Types.ActionType.CONTINUE -> "Continue"
-                    }
-                } with GAuth", style = TextStyle(
-                    fontFamily = pretendard,
-                    fontWeight = FontWeight.SemiBold,
-                    fontSize = 17.sp
+        Button(
+            onClick = onClick,
+            modifier = Modifier
+                .wrapContentSize()
+                .fillMaxWidth(horizontalFloat ?: 0.9f)
+                .clip(
+                    RoundedCornerShape(
+                        when (style) {
+                            Types.Style.DEFAULT -> 6.dp
+                            Types.Style.ROUNDED -> 26.dp
+                        }
+                    )
                 )
-            )
-            Spacer(modifier = Modifier.size(10.dp))
+                .border(
+                    if (colors == Types.Colors.OUTLINE) 1.dp else 0.dp,
+                    SolidColor(
+                        when (colors) {
+                            Types.Colors.OUTLINE -> GauthBlue
+                            Types.Colors.COLORED -> GauthBlue
+                            Types.Colors.WHITE -> Color.White
+                        }
+                    ),
+                    RoundedCornerShape(if (style == Types.Style.DEFAULT) 6.dp else 26.dp)
+                )
+                .align(Alignment.Center),
+            contentPadding = PaddingValues(
+                vertical = 14.dp,
+                horizontal = horizontalPaddingValue ?: 0.dp
+            ),
+            colors = ButtonDefaults.buttonColors(
+                backgroundColor = when (colors) {
+                    Types.Colors.COLORED -> GauthBlue
+                    else -> Color.White
+                },
+                contentColor = when (colors) {
+                    Types.Colors.WHITE -> GauthBlue
+                    Types.Colors.COLORED -> Color.White
+                    Types.Colors.OUTLINE -> GauthBlue
+                }
+            ),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Center
+            ) {
+                Icon(
+                    painter = painterResource(id = R.drawable.gauth_white_ic),
+                    contentDescription = "GAuthButtonIcon",
+                    modifier = Modifier
+                        .width(30.dp)
+                        .height(30.dp)
+                )
+                Text(
+                    text = "${
+                        when (actionType) {
+                            Types.ActionType.SIGNIN -> "Sign in"
+                            Types.ActionType.SIGNUP -> "Sign up"
+                            Types.ActionType.CONTINUE -> "Continue"
+                        }
+                    } with GAuth", style = TextStyle(
+                        fontFamily = pretendard,
+                        fontWeight = FontWeight.SemiBold,
+                        fontSize = 17.sp
+                    )
+                )
+                Spacer(modifier = Modifier.size(10.dp))
+            }
         }
     }
 }

--- a/GAuthSignin/src/main/java/com/msg/gauthsignin/component/GAuthButton.kt
+++ b/GAuthSignin/src/main/java/com/msg/gauthsignin/component/GAuthButton.kt
@@ -1,6 +1,5 @@
 package com.msg.gauthsignin.component
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -8,14 +7,12 @@ import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
@@ -25,9 +22,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.unit.toSize
 import com.msg.gauthsignin.R
-import com.msg.gauthsignin.component.ui.GauthBlue
+import com.msg.gauthsignin.component.ui.GAuthBlue
 import com.msg.gauthsignin.component.utils.Types
 
 @Composable
@@ -79,8 +75,8 @@ fun GAuthButton(
                     if (colors == Types.Colors.OUTLINE) 1.dp else 0.dp,
                     SolidColor(
                         when (colors) {
-                            Types.Colors.OUTLINE -> GauthBlue
-                            Types.Colors.COLORED -> GauthBlue
+                            Types.Colors.OUTLINE -> GAuthBlue
+                            Types.Colors.COLORED -> GAuthBlue
                             Types.Colors.WHITE -> Color.White
                         }
                     ),
@@ -92,13 +88,13 @@ fun GAuthButton(
             ),
             colors = ButtonDefaults.buttonColors(
                 backgroundColor = when (colors) {
-                    Types.Colors.COLORED -> GauthBlue
+                    Types.Colors.COLORED -> GAuthBlue
                     else -> Color.White
                 },
                 contentColor = when (colors) {
-                    Types.Colors.WHITE -> GauthBlue
+                    Types.Colors.WHITE -> GAuthBlue
                     Types.Colors.COLORED -> Color.White
-                    Types.Colors.OUTLINE -> GauthBlue
+                    Types.Colors.OUTLINE -> GAuthBlue
                 }
             ),
         ) {

--- a/GAuthSignin/src/main/java/com/msg/gauthsignin/component/GAuthButton.kt
+++ b/GAuthSignin/src/main/java/com/msg/gauthsignin/component/GAuthButton.kt
@@ -32,9 +32,9 @@ import com.msg.gauthsignin.component.utils.Types
 
 @Composable
 fun GAuthButton(
-    style: Types.Style,
-    actionType: Types.ActionType,
-    colors: Types.Colors,
+    style: Types.Style = Types.Style.DEFAULT,
+    actionType: Types.ActionType = Types.ActionType.SIGNIN,
+    colors: Types.Colors = Types.Colors.WHITE,
     horizontalPaddingValue: Dp? = null,
     horizontalPercent: Float? = null,
     horizontalMargin: Dp? = null,
@@ -49,17 +49,17 @@ fun GAuthButton(
     }
 
     val modifier = when {
-        horizontalMargin != null && horizontalPercent == null -> Modifier
+        horizontalMargin != null && horizontalPercent == null && horizontalPaddingValue == null -> Modifier
             .fillMaxWidth()
-            .wrapContentHeight()
 
-        horizontalMargin == null && horizontalPercent != null -> Modifier
+        horizontalMargin == null && horizontalPercent != null && horizontalPaddingValue == null -> Modifier
             .fillMaxWidth(horizontalPercent)
-            .wrapContentHeight()
+
+        horizontalMargin == null && horizontalPercent == null && horizontalPaddingValue != null -> Modifier
+            .wrapContentSize()
 
         else -> Modifier
             .fillMaxWidth(0.9f)
-            .wrapContentHeight()
     }
 
     Row(
@@ -68,8 +68,7 @@ fun GAuthButton(
             .padding(horizontal = horizontalMargin ?: 0.dp)
             .onGloballyPositioned {
                 parentSize = it.parentLayoutCoordinates?.size?.toSize() ?: Size.Zero
-            }
-            .background(Color.Blue),
+            },
         horizontalArrangement = Arrangement.Center
     ) {
         Button(
@@ -93,8 +92,7 @@ fun GAuthButton(
                         }
                     ),
                     RoundedCornerShape(if (style == Types.Style.DEFAULT) 6.dp else 26.dp)
-                )
-                .background(Color.Red),
+                ),
             contentPadding = PaddingValues(
                 vertical = 14.dp,
                 horizontal = horizontalPaddingValue ?: 0.dp

--- a/GAuthSignin/src/main/java/com/msg/gauthsignin/component/GAuthButton.kt
+++ b/GAuthSignin/src/main/java/com/msg/gauthsignin/component/GAuthButton.kt
@@ -32,7 +32,7 @@ fun GAuthButton(
     actionType: Types.ActionType,
     colors: Types.Colors,
     horizontalPaddingValue: Dp? = null,
-    horizontalFloat: Float? = null,
+    horizontalPercent: Float? = null,
     horizontalMargin: Dp? = null,
     onClick: () -> Unit
 ) {
@@ -49,7 +49,7 @@ fun GAuthButton(
             onClick = onClick,
             modifier = Modifier
                 .wrapContentSize()
-                .fillMaxWidth(horizontalFloat ?: 0.9f)
+                .fillMaxWidth(horizontalPercent ?: 0.9f)
                 .clip(
                     RoundedCornerShape(
                         when (style) {

--- a/GAuthSignin/src/main/java/com/msg/gauthsignin/component/GAuthButton.kt
+++ b/GAuthSignin/src/main/java/com/msg/gauthsignin/component/GAuthButton.kt
@@ -44,10 +44,6 @@ fun GAuthButton(
         Font(R.font.pretendardsemibold, FontWeight.SemiBold, FontStyle.Normal)
     )
 
-    var parentSize by remember {
-        mutableStateOf(Size.Zero)
-    }
-
     val modifier = when {
         horizontalMargin != null && horizontalPercent == null && horizontalPaddingValue == null -> Modifier
             .fillMaxWidth()
@@ -65,10 +61,7 @@ fun GAuthButton(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = horizontalMargin ?: 0.dp)
-            .onGloballyPositioned {
-                parentSize = it.parentLayoutCoordinates?.size?.toSize() ?: Size.Zero
-            },
+            .padding(horizontal = horizontalMargin ?: 0.dp),
         horizontalArrangement = Arrangement.Center
     ) {
         Button(

--- a/GAuthSignin/src/main/java/com/msg/gauthsignin/component/GAuthButton.kt
+++ b/GAuthSignin/src/main/java/com/msg/gauthsignin/component/GAuthButton.kt
@@ -1,5 +1,6 @@
 package com.msg.gauthsignin.component
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -7,12 +8,14 @@ import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
@@ -22,6 +25,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.unit.toSize
 import com.msg.gauthsignin.R
 import com.msg.gauthsignin.component.ui.GauthBlue
 import com.msg.gauthsignin.component.utils.Types
@@ -39,17 +43,38 @@ fun GAuthButton(
     val pretendard = FontFamily(
         Font(R.font.pretendardsemibold, FontWeight.SemiBold, FontStyle.Normal)
     )
-    Box(
-        modifier = Modifier
+
+    var parentSize by remember {
+        mutableStateOf(Size.Zero)
+    }
+
+    val modifier = when {
+        horizontalMargin != null && horizontalPercent == null -> Modifier
             .fillMaxWidth()
             .wrapContentHeight()
-            .padding(vertical = horizontalMargin ?: 0.dp),
+
+        horizontalMargin == null && horizontalPercent != null -> Modifier
+            .fillMaxWidth(horizontalPercent)
+            .wrapContentHeight()
+
+        else -> Modifier
+            .fillMaxWidth(0.9f)
+            .wrapContentHeight()
+    }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = horizontalMargin ?: 0.dp)
+            .onGloballyPositioned {
+                parentSize = it.parentLayoutCoordinates?.size?.toSize() ?: Size.Zero
+            }
+            .background(Color.Blue),
+        horizontalArrangement = Arrangement.Center
     ) {
         Button(
             onClick = onClick,
-            modifier = Modifier
-                .wrapContentSize()
-                .fillMaxWidth(horizontalPercent ?: 0.9f)
+            modifier = modifier
                 .clip(
                     RoundedCornerShape(
                         when (style) {
@@ -69,7 +94,7 @@ fun GAuthButton(
                     ),
                     RoundedCornerShape(if (style == Types.Style.DEFAULT) 6.dp else 26.dp)
                 )
-                .align(Alignment.Center),
+                .background(Color.Red),
             contentPadding = PaddingValues(
                 vertical = 14.dp,
                 horizontal = horizontalPaddingValue ?: 0.dp

--- a/GAuthSignin/src/main/java/com/msg/gauthsignin/component/ui/Color.kt
+++ b/GAuthSignin/src/main/java/com/msg/gauthsignin/component/ui/Color.kt
@@ -2,4 +2,4 @@ package com.msg.gauthsignin.component.ui
 
 import androidx.compose.ui.graphics.Color
 
-val GauthBlue = Color(0xFF2E80CC)
+val GAuthBlue = Color(0xFF2E80CC)


### PR DESCRIPTION
## 💡 개요
- 가로 길이 조정 방식을 추가합니다.

## 📃 작업내용
- margin값으로 가로길이를 조정할 수 있도록 합니다.
- 퍼센테이지로도 가로길이를 조정할 수 있도록 합니다.

## 🍴 사용방법
- horizontalMargin파라미터에 dp값을 줘서 가로길이를 조정할 수 있습니다.
- horizontalPercent파리미터에 float값을 줘서 가로길이를 퍼센트로 조정할 수 있습니다. ex) 0.9f -> 90%, 0.5f -> 50%